### PR TITLE
updated chart to use cert-mgr for TLS certs

### DIFF
--- a/templates/certificate.yaml
+++ b/templates/certificate.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.certificate.enabled -}}
+# Copyright (c) 2025, Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Source: iag4-helm/templates/certificate.yaml
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "iag.fullname" . }}-tls
+  labels:
+    {{- include "iag.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "iag.fullname" . }}-tls-secret
+  issuerRef:
+    name: {{ .Values.certificate.issuerRef.name }}
+    kind: {{ .Values.certificate.issuerRef.kind }}
+  commonName: {{ .Values.certificate.hostname }}
+  dnsNames:
+    - {{ .Values.certificate.hostname }}
+  renewBefore: {{ .Values.certificate.renewBefore }}
+  duration: {{ .Values.certificate.duration }}
+{{- end -}}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
 
     # The port on which Automation Gateway server will listen for requests.
     # Mutually exclusive with bind_list
-    port: {{ .Values.configMap.propertiesYaml.port }}
+    port: {{ .Values.applicationPort }}
 
     # The gunicorn bind_address string..
     # For ipv4 only use "0.0.0.0", for ipv6 and ipv4 use "[::]"
@@ -47,7 +47,7 @@ data:
     # List of addresses and ports to bind to.
     # This setting will override both 'port' and 'bind_address'
     #bind_list:
-    #  - "{{ .Values.configMap.propertiesYaml.bindAddress }}:{{ .Values.configMap.propertiesYaml.port }}"
+    #  - "{{ .Values.configMap.propertiesYaml.bindAddress }}:{{ .Values.applicationPort }}"
 
     # Base of url for external proxy, used for generating redirects:
     # external_address: 'http://automation-gateway.example.com:8080'
@@ -95,26 +95,28 @@ data:
     #          variable from your host's variables "commands", etc.
     strict_args: true
 
+    {{- if .Values.useTLS }}
     ################
     # SSL Settings #
     ################
 
     # To start the server using SSL/TLS please fill out the following properties.
-    # server_certfile: ""
+    server_certfile: "/etc/ssl/gateway/tls.crt"
 
     # Note: gunicorn does not currently support encrypted key files.
-    # server_keyfile: ""
+    server_keyfile: "/etc/ssl/gateway/tls.key"
 
-    # server_cabundle: ""
+    server_cabundle: "/etc/ssl/gateway/ca.crt"
 
     # TLSv1_2
-    # server_ssl_version: "TLSv1_2"
+    server_ssl_version: "TLSv1_2"
 
     # You may also set custom SSL Ciphers.
     #
     # https://docs.gunicorn.org/en/20.x/settings.html#ciphers
     #
     # server_ssl_ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:...""
+    {{- end }}
 
     #############
     # Databases #

--- a/templates/issuer.yaml
+++ b/templates/issuer.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.issuer.enabled -}}
+# Copyright (c) 2025, Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Source: iag4-helm/templates/issuer.yaml
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.issuer.name }}
+  labels:
+    {{- include "iag.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ .Values.issuer.caSecretName }}
+{{- end -}}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
   ports:
     - name: http
       port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
+      targetPort: {{ .Values.applicationPort }}
       protocol: TCP
   selector:
     {{- include "iag.selectorLabels" . | nindent 4 }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -44,17 +44,39 @@ spec:
           - name: http
             containerPort: {{ .Values.service.port }}
             protocol: TCP
-        {{- if .Values.startupProbeEnabled }}
+        {{- if .Values.startupProbe.enabled }}
         startupProbe:
-          {{- toYaml .Values.startupProbe | nindent 10 }}
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          httpGet:
+            path: {{ .Values.startupProbe.path }}
+            port: {{ .Values.applicationPort }}
+            scheme: {{ ternary "HTTPS" "HTTP" .Values.useTLS }}
+          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
         {{- end }}
-        {{- if .Values.livenessProbeEnabled }}
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
-          {{- toYaml .Values.livenessProbe | nindent 10 }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          httpGet:
+            path: {{ .Values.livenessProbe.path }}
+            port: {{ .Values.applicationPort }}
+            scheme: {{ ternary "HTTPS" "HTTP" .Values.useTLS }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         {{- end }}
-        {{- if .Values.readinessProbeEnabled }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
-          {{- toYaml .Values.readinessProbe | nindent 10 }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          httpGet:
+            path: {{ .Values.readinessProbe.path }}
+            port: {{ .Values.applicationPort }}
+            scheme: {{ ternary "HTTPS" "HTTP" .Values.useTLS }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         {{- end }}
         {{- if .Values.resourcesEnabled }}
         resources:  {{- toYaml .Values.resources | nindent 10 }}
@@ -64,10 +86,10 @@ spec:
           - name: "config-volume"
             mountPath: "/etc/automation-gateway/properties.yml"
             subPath: "properties.yml"
-          {{- range $path, $_ := .Files.Glob "files/certificates/*.*" }}
-          - name: "config-certs"
-            mountPath: "/etc/ssl/certs/{{ base ($path) }}"
-            subPath: {{ base ($path) }}
+          {{- if .Values.useTLS }}
+          - name: gateway-cert-volume
+            mountPath: /etc/ssl/gateway
+            readOnly: true
           {{- end }}
           # Uses a configmap to mount a customized ansible config file at the below path
           - name: "config-volume"
@@ -92,10 +114,10 @@ spec:
         - name: "config-volume"
           configMap:
             name: "iag-config-map"
-        {{- if .Files.Glob "files/certificates/*.*" }}
-        - name: "config-certs"
+        {{- if .Values.useTLS }}
+        - name: gateway-cert-volume
           secret:
-            secretName: "iag-certificates"
+            secretName: {{ include "iag.fullname" . }}-tls-secret
         {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/tests/configmap_test.yaml
+++ b/tests/configmap_test.yaml
@@ -63,7 +63,6 @@ tests:
   - it: should configure port correctly
     set:
       configMap.enabled: true
-      configMap.propertiesYaml.port: 9090
       configMap.propertiesYaml.bindAddress: "0.0.0.0"
       configMap.propertiesYaml.serverThreads: 4
       configMap.propertiesYaml.logDir: "/var/log/automation-gateway"
@@ -82,7 +81,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["properties.yml"]
-          pattern: "port: 9090"
+          pattern: "port: 8083"
 
   - it: should configure bind address correctly
     set:

--- a/tests/service_test.yaml
+++ b/tests/service_test.yaml
@@ -50,18 +50,17 @@ tests:
       service:
         name: clusterip-service
         type: ClusterIP
-        port: 3000
-        targetPort: 3000
+        port: 443
     asserts:
       - equal:
           path: spec.type
           value: ClusterIP
       - equal:
           path: spec.ports[0].port
-          value: 3000
+          value: 443
       - equal:
           path: spec.ports[0].targetPort
-          value: 3000
+          value: 8083
 
   - it: should configure NodePort service
     set:
@@ -69,7 +68,6 @@ tests:
         name: nodeport-service
         type: NodePort
         port: 80
-        targetPort: 8080
     asserts:
       - equal:
           path: spec.type
@@ -79,7 +77,7 @@ tests:
           value: 80
       - equal:
           path: spec.ports[0].targetPort
-          value: 8080
+          value: 8083
 
   - it: should configure LoadBalancer service
     set:
@@ -87,7 +85,6 @@ tests:
         name: lb-service
         type: LoadBalancer
         port: 443
-        targetPort: 8443
     asserts:
       - equal:
           path: spec.type
@@ -97,7 +94,7 @@ tests:
           value: 443
       - equal:
           path: spec.ports[0].targetPort
-          value: 8443
+          value: 8083
 
   - it: should set correct port configuration
     set:
@@ -105,7 +102,6 @@ tests:
         name: test-service
         type: ClusterIP
         port: 9000
-        targetPort: 9090
     asserts:
       - lengthEqual:
           path: spec.ports
@@ -118,34 +114,21 @@ tests:
           value: 9000
       - equal:
           path: spec.ports[0].targetPort
-          value: 9090
+          value: 8083
       - equal:
           path: spec.ports[0].protocol
           value: TCP
 
-  - it: should handle string targetPort
+  - it: should set the configured numeric targetPort
     set:
       service:
         name: test-service
         type: ClusterIP
         port: 80
-        targetPort: "http-port"
     asserts:
       - equal:
           path: spec.ports[0].targetPort
-          value: "http-port"
-
-  - it: should handle numeric targetPort
-    set:
-      service:
-        name: test-service
-        type: ClusterIP
-        port: 80
-        targetPort: 8080
-    asserts:
-      - equal:
-          path: spec.ports[0].targetPort
-          value: 8080
+          value: 8083
 
   - it: should include selector labels
     set:
@@ -153,7 +136,6 @@ tests:
         name: test-service
         type: ClusterIP
         port: 80
-        targetPort: 8080
     asserts:
       - isNotNull:
           path: spec.selector
@@ -169,56 +151,10 @@ tests:
         name: api-gateway-service
         type: ClusterIP
         port: 8080
-        targetPort: 8080
     asserts:
       - equal:
           path: metadata.name
           value: api-gateway-service
-
-  - it: should work with high port numbers
-    set:
-      service:
-        name: test-service
-        type: ClusterIP
-        port: 65535
-        targetPort: 65534
-    asserts:
-      - equal:
-          path: spec.ports[0].port
-          value: 65535
-      - equal:
-          path: spec.ports[0].targetPort
-          value: 65534
-
-  - it: should work with standard HTTP port
-    set:
-      service:
-        name: web-service
-        type: ClusterIP
-        port: 80
-        targetPort: 80
-    asserts:
-      - equal:
-          path: spec.ports[0].port
-          value: 80
-      - equal:
-          path: spec.ports[0].targetPort
-          value: 80
-
-  - it: should work with standard HTTPS port
-    set:
-      service:
-        name: secure-service
-        type: ClusterIP
-        port: 443
-        targetPort: 8443
-    asserts:
-      - equal:
-          path: spec.ports[0].port
-          value: 443
-      - equal:
-          path: spec.ports[0].targetPort
-          value: 8443
 
   - it: should always set protocol to TCP
     set:

--- a/tests/statefulset_test.yaml
+++ b/tests/statefulset_test.yaml
@@ -264,7 +264,7 @@ tests:
         port: 8080
       podSecurityContext: {}
       securityContext: {}
-      startupProbeEnabled: true
+      startupProbe.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -289,7 +289,7 @@ tests:
         port: 8080
       podSecurityContext: {}
       securityContext: {}
-      livenessProbeEnabled: true
+      livenessProbe.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -311,7 +311,7 @@ tests:
         port: 8080
       podSecurityContext: {}
       securityContext: {}
-      readinessProbeEnabled: true
+      readinessProbe.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,9 @@
 
 replicaCount: 1
 
+applicationPort: 8083
+useTLS: false
+
 # image The Itential image to use, its version, and its location
 image:
   repository: 497639811223.dkr.ecr.us-east-2.amazonaws.com/automation-gateway
@@ -17,6 +20,20 @@ imagePullSecrets: []
 # # ServiceAccount with IRSA
 serviceAccount:
   name:
+
+issuer:
+  enabled: false
+  name: iag-ca-issuer
+  caSecretName:
+
+certificate:
+  enabled: false
+  issuerRef:
+    name: iag-ca-issuer
+    kind: Issuer
+  renewBefore:
+  duration:
+  hostname:
 
 # storageClass This is used to configure the storage class object which governs
 # how the mounted volumes are created.
@@ -51,8 +68,6 @@ service:
   name: "iag-service"
   # port The port that this service object is listening on
   port: 80
-  # targetPort The application port that this service object will send requests to
-  targetPort: 8083
 
 # ingress The Kubernetes ingress object for this application.
 ingress:
@@ -103,44 +118,38 @@ resources:
 # the kubelet kills the container, and the container is subjected to its restart policy. If a
 # container does not provide a liveness probe, the default state is Success. These are suggested
 # values.
-livenessProbeEnabled: false
 livenessProbe:
+  enabled: false
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
   successThreshold: 1
-  httpGet:
-    path: "/api/v2.0/poll"
-    port: 8083
+  path: "/api/v2.0/poll"
 
 # The readiness probe used to determine if the container is ready to accept requests. If the
 # readiness probe fails, the endpoints controller removes the pod’s IP address from the
 # endpoints of all services that match the pod. The default state of readiness before the
 # initial delay is failure. If a container does not provide a readiness probe, the default
 # state is success. These are suggested values.
-readinessProbeEnabled: false
 readinessProbe:
+  readinessProbe: false
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
   successThreshold: 1
-  httpGet:
-    path: "/api/v2.0/poll"
-    port: 8083
+  path: "/api/v2.0/poll"
 
 # The startup probe used to allow some time for the application to start up. The application
 # will have a maximum of 3 minutes (18 * 10 = 180s) to finish its startup. Once the startup
 # probe has succeeded once, the liveness probe takes over. These are suggested values.
-startupProbeEnabled: false
 startupProbe:
+  enabled: false
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 18
   successThreshold: 1
-  httpGet:
-    path: "/api/v2.0/poll"
-    port: 8083
+  path: "/api/v2.0/poll"
 
 # propertiesYaml This is used to generate the IAG config file that the IAG
 # application will use. These properties are all passed into the configmap
@@ -148,21 +157,21 @@ startupProbe:
 configMap:
   enabled: true
   propertiesYaml:
-    port: 8083
     bindAddress: "0.0.0.0"
     serverThreads: 8
     logDir: "/var/lib/automation-gateway"
     dataDir: "/var/lib/automation-gateway"
+    # LDAP configuration properties
     enableAnsible: true
     ansibleDebug: false
     customDir: "/usr/share/automation-gateway"
-    enableHttp: false
+    enableHttp: true
     enableNetconf: true
-    enableNetmiko: false
-    enableNornir: false
+    enableNetmiko: true
+    enableNornir: true
     enableScripts: true
     enablePythonVenvs: true
-    enableGrpc: false
+    enableGrpc: true
     enableGit: true
 
 # volumes Additional volumes on the output Deployment definition.


### PR DESCRIPTION
Added cert-mgr to Kubernetes cluster to manage the TLS certificates. Reworked some of the templates to consolidate the application port into a single property. Updated associated unit tests.