### PR TITLE
Fix unit test, lint errors

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -62,11 +62,11 @@ spec:
             value: "sqlite:////var/lib/automation-gateway/automation-gateway_exec_history.db"
           {{- if .Values.useTLS }}
           - name: automation_gateway_server_certfile
-            value: "/etc/ssl/gateway/server.crt"
+            value: "/etc/ssl/gateway/tls.crt"
           - name: automation_gateway_server_keyfile
-            value: "/etc/ssl/gateway/server.key"
+            value: "/etc/ssl/gateway/tls.key"
           - name: automation_gateway_server_cabundle
-            value: "/etc/ssl/gateway/ca-bundle.crt"
+            value: "/etc/ssl/gateway/ca.crt"
           {{- end }}
           {{/* Additional Ansible settings */}}
           - name: automation_gateway_ansible_enabled
@@ -232,16 +232,7 @@ spec:
         volumeMounts:
           {{- if .Values.useTLS }}
           - name: gateway-cert-volume
-            mountPath: /etc/ssl/gateway/server.crt
-            subPath: tls.crt
-            readOnly: true
-          - name: gateway-cert-volume
-            mountPath: /etc/ssl/gateway/server.key
-            subPath: tls.key
-            readOnly: true
-          - name: gateway-cert-volume
-            mountPath: /etc/ssl/gateway/ca-bundle.crt
-            subPath: ca.crt
+            mountPath: /etc/ssl/gateway
             readOnly: true
           {{- end }}
           {{- if .Values.configMap.enabled }}

--- a/tests/statefulset_test.yaml
+++ b/tests/statefulset_test.yaml
@@ -110,13 +110,13 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == "automation_gateway_server_certfile")].value
-          value: "/etc/ssl/gateway/server.crt"
+          value: "/etc/ssl/gateway/tls.crt"
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == "automation_gateway_server_keyfile")].value
-          value: "/etc/ssl/gateway/server.key"
+          value: "/etc/ssl/gateway/tls.key"
       - equal:
           path: spec.template.spec.containers[0].env[?(@.name == "automation_gateway_server_cabundle")].value
-          value: "/etc/ssl/gateway/ca-bundle.crt"
+          value: "/etc/ssl/gateway/ca.crt"
 
   # Test 6: Test TLS volume mounts
   - it: should mount TLS volumes when useTLS is true
@@ -132,8 +132,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: gateway-cert-volume
-            mountPath: /etc/ssl/gateway/server.crt
-            subPath: tls.crt
+            mountPath: /etc/ssl/gateway
             readOnly: true
       - contains:
           path: spec.template.spec.volumes

--- a/values.yaml
+++ b/values.yaml
@@ -70,7 +70,7 @@ storageClass:
   # -- Toggle the use of storageClass
   enabled: true
   # -- The name of the storageClass
-  name: "iag-ebs-gp3"
+  name: "example-class"
   # -- Specifies which volume plugin provisions the storage
   provisioner: "" # suggested ebs.csi.aws.com
   # -- What happens to PersistentVolumes when released. Itential recommends "retain".
@@ -197,15 +197,10 @@ volumes: []
 volumeMounts: []
 
 # -- Additional nodeSelectors
-nodeSelector:
-  itential.io/app: "iag"
+nodeSelector: {}
 
-# -- Additional tolerations
-tolerations:
-- effect: "NoSchedule"
-  key: "itential.io/role"
-  operator: "Equal"
-  value: "iag"
+# # -- Additional tolerations
+tolerations: {}
 
 # -- Additional affinity
 affinity: {}
@@ -242,7 +237,7 @@ applicationSettings:
   # -- The host name of the Hashicorp Vault server.
   hvHost: "hashivault.example.com"
   # -- Use TLS when connecting to Hashicorp Vault server.
-  hvTLS: true
+  hvTLS: false
   # -- Enables certificate verification.
   hvCertVerification: false
   # -- The mount point.


### PR DESCRIPTION
Simplified the mount files in the statefulset by removing the individual mount points and replacing it with a directory mount. Adjusted tests. Fix lint errors.