### PR TITLE
Change liveness probe to count running processes, instead of http hea…

### DIFF
--- a/charts/iag4/Chart.yaml
+++ b/charts/iag4/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/iag4/templates/statefulset.yaml
+++ b/charts/iag4/templates/statefulset.yaml
@@ -207,10 +207,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          httpGet:
-            path: {{ .Values.livenessProbe.path }}
-            port: {{ .Values.applicationPort }}
-            scheme: {{ ternary "HTTPS" "HTTP" .Values.useTLS }}
+          {{- toYaml .Values.livenessProbe.probe | nindent 10 }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/charts/iag4/tests/statefulset_test.yaml
+++ b/charts/iag4/tests/statefulset_test.yaml
@@ -293,14 +293,18 @@ tests:
         timeoutSeconds: 10
         failureThreshold: 5
         successThreshold: 1
-        path: "/health"
+        probe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - test $(ps | grep '[a]utomation-gateway' | wc -l) -eq 2
       applicationSettings:
         enabled: true
         env: {}
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
-          value: "HTTP"
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.periodSeconds
           value: 20

--- a/charts/iag4/values.yaml
+++ b/charts/iag4/values.yaml
@@ -152,14 +152,19 @@ resources:
 # The liveness probe used to determine if the container is alive. If the liveness probe fails,
 # the kubelet kills the container, and the container is subjected to its restart policy. If a
 # container does not provide a liveness probe, the default state is Success. These are suggested
-# values.
+# values. Check that there are 2 processes running. If not, then the app is not live.
 livenessProbe:
   enabled: false
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
   successThreshold: 1
-  path: "/api/v2.0/poll"
+  probe:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - test $(ps | grep '[a]utomation-gateway' | wc -l) -eq 2
 
 # The readiness probe used to determine if the container is ready to accept requests. If the
 # readiness probe fails, the endpoints controller removes the pod’s IP address from the


### PR DESCRIPTION
Change liveness probe to count running processes, instead of http health check. This should help the pod stay alive when HTTP traffic increases and liveness probe fails while checking the HTTP route.